### PR TITLE
Check app.login_manager for Flask-Login

### DIFF
--- a/flask_paranoid/paranoid.py
+++ b/flask_paranoid/paranoid.py
@@ -1,5 +1,4 @@
 from hashlib import sha256
-import sys
 
 from flask import session, request, make_response, url_for, current_app, \
     redirect
@@ -107,7 +106,7 @@ class Paranoid(object):
 
         # if flask-login is installed, we try to clear the
         # "remember me" cookie, just in case it is set
-        if 'flask_login' in sys.modules:
+        if getattr(current_app, 'login_manager', None):
             remember_cookie = current_app.config.get('REMEMBER_COOKIE',
                                                      'remember_token')
             response.set_cookie(remember_cookie, '', expires=0, max_age=0)

--- a/tests/test_paranoid.py
+++ b/tests/test_paranoid.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 from flask import Flask
@@ -154,7 +153,7 @@ class ParanoidTests(unittest.TestCase):
             return 'foobar'
 
         client = app.test_client(use_cookies=True)
-        sys.modules['flask_login'] = 'foo'
+        app.login_manager = 'foo'
 
         self.assertEqual(paranoid.redirect_view, 'https://foo.com/foobarbaz')
 
@@ -162,7 +161,7 @@ class ParanoidTests(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
 
         rv = client.get('/', headers={'User-Agent': 'bar'})
-        del sys.modules['flask_login']
+        delattr(app, 'login_manager')
         self.assertEqual(rv.status_code, 302)
         self.assertEqual(rv.headers['Location'], 'https://foo.com/foobarbaz')
         self.assertIn(self._delete_cookie('session'),


### PR DESCRIPTION
Instead of checking for flask_login in sys.modules, check that current_app.login_manager has been populated. It's nicer, and also a better check (because it will only be true if Flask-Login is enabled for the current app, not enough if it's just installed in the current Python env).